### PR TITLE
Get rid of Thread.exclusive deprecation, Upgrade to Sidekiq 4

### DIFF
--- a/lib/sidekiq/throttler/version.rb
+++ b/lib/sidekiq/throttler/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   class Throttler
-    VERSION = '0.4.1'
+    VERSION = '0.5.0'
   end
 end

--- a/sidekiq-throttler.gemspec
+++ b/sidekiq-throttler.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w(lib)
 
   gem.add_dependency 'activesupport'
-  gem.add_dependency 'sidekiq', '>= 2.5', '< 4.0'
+  gem.add_dependency 'sidekiq', '>= 2.5', '< 5.0'
 
   gem.add_development_dependency 'growl'
   gem.add_development_dependency 'guard'


### PR DESCRIPTION
Removes deprecation warning for `Thread.exclusive`, and updates gem specs to Sidekiq 4.

Had 0 deprecation warning for Sidekiq 4, only deprecation was the `Thread.exclusive` one.

Also bumps Gem version to 0.5.0
